### PR TITLE
Allow Action to be run manually

### DIFF
--- a/.github/workflows/export-notion-blocks-and-commit.yml
+++ b/.github/workflows/export-notion-blocks-and-commit.yml
@@ -1,6 +1,7 @@
 name: 'Export Notion Blocks and Commit to Git'
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/export-notion-blocks-and-commit.yml
+++ b/.github/workflows/export-notion-blocks-and-commit.yml
@@ -1,12 +1,12 @@
 name: 'Export Notion Blocks and Commit to Git'
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   export-notion-blocks-and-commit:


### PR DESCRIPTION
Allows the Action to be run manually from `Actions` -> `Export Notion Blocks and Commit to Git`, for example after changing the `NOTION_TOKEN`.