### PR TITLE
Add instruction to give Action workflows write permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 ## Setup
 
 1. Click on the green "Use this template" button at the top to make your own copy of this repository - make sure to choose "Private" visibility, unless you want to make your Notion content visible to the public
-2. Create a new repo secret under Settings -> Secrets called `NOTION_TOKEN` with the instructions in [this article](https://archive.ph/b5mgg)
-3. Edit `index.ts` to add the Notion pages you want to export to the `blocks` array at the top of the file
-4. Optional: Edit `index.ts` to specify a different export format, time zone or locale
-5. Optional: Edit `.github/workflows/export-notion-blocks-and-commit.yml` to specify a different schedule (default is once per day)
-6. After the `Export Notion Blocks and Commit to Git` workflow has run, your backup will have been committed to your GitHub repo in the `exports` folder! 🙌
+2. Give Action workflows read and write permissions to the repository under Settings -> Actions -> General -> Workflow permissions
+3. Create a new repo secret under Settings -> Secrets called `NOTION_TOKEN` with the instructions in [this article](https://archive.ph/b5mgg)
+4. Edit `index.ts` to add the Notion pages you want to export to the `blocks` array at the top of the file
+5. Optional: Edit `index.ts` to specify a different export format, time zone or locale
+6. Optional: Edit `.github/workflows/export-notion-blocks-and-commit.yml` to specify a different schedule (default is once per day)
+7. After the `Export Notion Blocks and Commit to Git` workflow has run, your backup will have been committed to your GitHub repo in the `exports` folder! 🙌
 
 ## How
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ## Setup
 
 1. Click on the green "Use this template" button at the top to make your own copy of this repository - make sure to choose "Private" visibility, unless you want to make your Notion content visible to the public
-2. Give Action workflows read and write permissions to the repository under Settings -> Actions -> General -> Workflow permissions
-3. Create a new repo secret under Settings -> Secrets called `NOTION_TOKEN` with the instructions in [this article](https://archive.ph/b5mgg)
+2. Under Settings -> Actions -> General -> Workflow, scroll down to the Workflow Permissions section and select `Read and write permissions` (this is to allow the Actions workflow to write your Notion content to your repo)
+3. Under Settings -> Secrets and Variables -> Actions, create a new repository secret called `NOTION_TOKEN` with the instructions in [this article](https://archive.ph/b5mgg)
 4. Edit `index.ts` to add the Notion pages you want to export to the `blocks` array at the top of the file
 5. Optional: Edit `index.ts` to specify a different export format, time zone or locale
 6. Optional: Edit `.github/workflows/export-notion-blocks-and-commit.yml` to specify a different schedule (default is once per day)


### PR DESCRIPTION
# Why
Without write access to repository, the Action fails with `remote: Write access to repository not granted`

# What
`README`: Add step to `Setup` section to give Action workflows write permission