### PR TITLE
Fix `403` error by adding new API cookie

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -111,7 +111,7 @@ while (true) {
 
   const {
     data: { results },
-    headers: { 'set-cookie': setCookieHeader },
+    headers: { 'set-cookie': getTasksRequestCookies },
   }: { data: { results: Task[] }; headers: { 'set-cookie': string[] } } =
     await client.post('getTasks', {
       taskIds: taskIds,
@@ -151,9 +151,9 @@ while (true) {
         url: block.task.status.exportURL || undefined,
         responseType: 'stream',
         headers: {
-          Cookie: `${setCookieHeader.find((cookie) =>
+          Cookie: getTasksRequestCookies.find((cookie) =>
             cookie.includes('file_token='),
-          )}; token_v2=${process.env.NOTION_TOKEN}`,
+          ),
         },
       });
 

--- a/index.ts
+++ b/index.ts
@@ -117,8 +117,6 @@ while (true) {
       taskIds: taskIds,
     });
 
-  const fileToken = setCookies.find((x) => x.includes('file_token='));
-
   const blocksWithTaskProgress = results.reduce((blocksAcc, task) => {
     const block = enqueuedBlocks.find(({ task: { id } }) => id === task.id);
 
@@ -153,7 +151,9 @@ while (true) {
         url: block.task.status.exportURL || undefined,
         responseType: 'stream',
         headers: {
-          Cookie: `${fileToken}; token_v2=${process.env.NOTION_TOKEN}`,
+          Cookie: `${setCookies.find((setCookieHeader) =>
+            setCookieHeader.includes('file_token='),
+          )}; token_v2=${process.env.NOTION_TOKEN}`,
         },
       });
 

--- a/index.ts
+++ b/index.ts
@@ -111,9 +111,13 @@ while (true) {
 
   const {
     data: { results },
-  }: { data: { results: Task[] } } = await client.post('getTasks', {
-    taskIds: taskIds,
-  });
+    headers: { 'set-cookie': setCookies },
+  }: { data: { results: Task[] }; headers: { 'set-cookie': string[] } } =
+    await client.post('getTasks', {
+      taskIds: taskIds,
+    });
+
+  const fileToken = setCookies.find((x) => x.includes('file_token='));
 
   const blocksWithTaskProgress = results.reduce((blocksAcc, task) => {
     const block = enqueuedBlocks.find(({ task: { id } }) => id === task.id);
@@ -148,6 +152,9 @@ while (true) {
         method: 'GET',
         url: block.task.status.exportURL || undefined,
         responseType: 'stream',
+        headers: {
+          Cookie: `${fileToken}; token_v2=${process.env.NOTION_TOKEN}`,
+        },
       });
 
       const sizeInMb = Number(response.headers['content-length']) / 1000 / 1000;

--- a/index.ts
+++ b/index.ts
@@ -111,7 +111,7 @@ while (true) {
 
   const {
     data: { results },
-    headers: { 'set-cookie': setCookies },
+    headers: { 'set-cookie': setCookieHeader },
   }: { data: { results: Task[] }; headers: { 'set-cookie': string[] } } =
     await client.post('getTasks', {
       taskIds: taskIds,
@@ -151,8 +151,8 @@ while (true) {
         url: block.task.status.exportURL || undefined,
         responseType: 'stream',
         headers: {
-          Cookie: `${setCookies.find((setCookieHeader) =>
-            setCookieHeader.includes('file_token='),
+          Cookie: `${setCookieHeader.find((cookie) =>
+            cookie.includes('file_token='),
           )}; token_v2=${process.env.NOTION_TOKEN}`,
         },
       });


### PR DESCRIPTION
lately, the script has been failing with a `403` error:

```sh
AxiosError: Request failed with status code 403

 response: {
     status: 403,
     statusText: 'Forbidden',
    ... 
```

this issue was also documented in this issue for `notion-guardian` https://github.com/richartkeil/notion-guardian/issues/11

After some research we found the Notion team updated the API to include a file token cookie credential for file download, this was causing the script to fail. This PR get the file token from the set-cookie header and pass it to the file request.

